### PR TITLE
feat/add draganddrop pdf merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+1.  Pertama, pikirkan masalahnya, baca *codebase* untuk menemukan berkas yang relevan, dan tulis rencana ke `tasks/todo.md`.
+2.  Rencana harus memiliki daftar item *todo* yang dapat Anda centang saat Anda menyelesaikannya.
+3.  Sebelum Anda mulai bekerja, periksa dengan saya dan saya akan memverifikasi rencana tersebut.
+4.  Kemudian, mulailah mengerjakan item *todo*, tandai sebagai selesai seiring Anda mengerjakannya.
+5.  Tolong setiap langkah berikan saya penjelasan tingkat tinggi tentang perubahan apa yang Anda buat.
+6.  Buat setiap tugas dan perubahan kode yang Anda lakukan sesederhana mungkin. Kami ingin menghindari perubahan besar-besaran atau kompleks. Setiap perubahan harus memengaruhi sesedikit mungkin kode. Segalanya adalah tentang kesederhanaan.
+7.  Terakhir, tambahkan bagian tinjauan ke berkas `todo.md` dengan ringkasan perubahan yang Anda buat dan informasi relevan lainnya.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "concurrently \"npm run dev:vite\" \"npm run dev:electron\"",
     "dev:vite": "vite",
-    "dev:electron": "wait-on http://localhost:5173 && cross-env NODE_ENV=development electron .",
+    "dev:electron": "npm run build:electron && wait-on http://localhost:5173 && cross-env NODE_ENV=development electron .",
     "build": "npm run build:vite && npm run build:electron",
     "build:vite": "vite build",
     "build:electron": "tsc -p tsconfig.main.json",

--- a/src/renderer/components/editing/MergeDialog.test.tsx
+++ b/src/renderer/components/editing/MergeDialog.test.tsx
@@ -129,6 +129,31 @@ describe('MergeDialog', () => {
     expect(getPageCountMock).toHaveBeenCalledTimes(2);
   });
 
+  it('appends a dropped PDF when it lands on an existing file row', async () => {
+    render(<MergeDialog open onClose={vi.fn()} />);
+
+    const dropZone = screen.getByLabelText('Drag and drop files here');
+    const alpha = createFile('alpha.pdf');
+    const beta = createFile('beta.pdf');
+
+    fireEvent.drop(dropZone, { dataTransfer: createDataTransfer([alpha]) });
+    await screen.findByText('alpha.pdf');
+
+    const alphaRow = screen.getByText('alpha.pdf').closest('[draggable="true"]');
+    expect(alphaRow).not.toBeNull();
+
+    fireEvent.dragOver(alphaRow as HTMLElement, {
+      dataTransfer: createDataTransfer([beta]),
+    });
+    fireEvent.drop(alphaRow as HTMLElement, {
+      dataTransfer: createDataTransfer([beta]),
+    });
+
+    expect(await screen.findByText('beta.pdf')).not.toBeNull();
+    expect(getRenderedFileNames()).toEqual(['alpha.pdf', 'beta.pdf']);
+    expect(getPageCountMock).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps arrow-button reordering working after drag support is added', async () => {
     render(<MergeDialog open onClose={vi.fn()} />);
 

--- a/src/renderer/components/editing/MergeDialog.test.tsx
+++ b/src/renderer/components/editing/MergeDialog.test.tsx
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MergeDialog } from './MergeDialog';
+import { pdfManipulationService } from '../../lib/pdf-manipulation.service';
+import { useEditingStore } from '../../store/editing-store';
+import { usePDFStore } from '../../store/pdf-store';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'merge.title': 'Merge PDFs',
+        'merge.description': 'Combine multiple PDF files into one',
+        'merge.addFiles': 'Add Files',
+        'merge.dragDrop': 'Drag and drop files here',
+        'merge.dropHint': 'or click Add Files to choose more PDFs',
+        'merge.reorderHint': 'Drag files to reorder merge order',
+        'merge.invalidDrop': 'Only PDF files can be added here',
+        'merge.mergeButton': 'Merge PDFs',
+        'common.cancel': 'Cancel',
+      };
+
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('../../lib/pdf-manipulation.service', () => ({
+  pdfManipulationService: {
+    getPageCount: vi.fn(),
+    mergePDFs: vi.fn(),
+  },
+}));
+
+const getPageCountMock = vi.mocked(pdfManipulationService.getPageCount);
+
+const createDataTransfer = (files: File[] = [], types: string[] = ['Files']) => ({
+  files,
+  types,
+  dropEffect: 'move',
+  effectAllowed: 'all',
+  setData: vi.fn(),
+  getData: vi.fn(),
+});
+
+const createFile = (name: string, type = 'application/pdf') => {
+  return new File(['file-content'], name, { type });
+};
+
+const getRenderedFileNames = () => {
+  return screen.getAllByText(/\.pdf$/).map((element) => element.textContent);
+};
+
+describe('MergeDialog', () => {
+  beforeEach(() => {
+    getPageCountMock.mockReset();
+    getPageCountMock.mockResolvedValue(1);
+
+    useEditingStore.getState().reset();
+    usePDFStore.setState({
+      document: null,
+      fileName: null,
+      totalPages: 0,
+    });
+  });
+
+  it('appends dropped PDF files to the merge list', async () => {
+    render(<MergeDialog open onClose={vi.fn()} />);
+
+    const dropZone = screen.getByLabelText('Drag and drop files here');
+    const alpha = createFile('alpha.pdf');
+    const beta = createFile('beta.pdf');
+
+    fireEvent.dragEnter(dropZone, { dataTransfer: createDataTransfer([alpha, beta]) });
+    fireEvent.drop(dropZone, { dataTransfer: createDataTransfer([alpha, beta]) });
+
+    expect(await screen.findByText('alpha.pdf')).not.toBeNull();
+    expect(await screen.findByText('beta.pdf')).not.toBeNull();
+    expect(getPageCountMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows an error when the drop contains no PDF files', async () => {
+    render(<MergeDialog open onClose={vi.fn()} />);
+
+    const dropZone = screen.getByLabelText('Drag and drop files here');
+    const textFile = createFile('notes.txt', 'text/plain');
+
+    fireEvent.drop(dropZone, { dataTransfer: createDataTransfer([textFile]) });
+
+    expect(await screen.findByText('Only PDF files can be added here')).not.toBeNull();
+    expect(screen.queryByText('notes.txt')).toBeNull();
+    expect(getPageCountMock).not.toHaveBeenCalled();
+  });
+
+  it('reorders uploaded files via drag and drop without re-adding them', async () => {
+    render(<MergeDialog open onClose={vi.fn()} />);
+
+    const dropZone = screen.getByLabelText('Drag and drop files here');
+    const alpha = createFile('alpha.pdf');
+    const beta = createFile('beta.pdf');
+
+    fireEvent.drop(dropZone, { dataTransfer: createDataTransfer([alpha, beta]) });
+    await screen.findByText('alpha.pdf');
+    await screen.findByText('beta.pdf');
+
+    const alphaRow = screen.getByText('alpha.pdf').closest('[draggable="true"]');
+    const betaRow = screen.getByText('beta.pdf').closest('[draggable="true"]');
+
+    expect(alphaRow).not.toBeNull();
+    expect(betaRow).not.toBeNull();
+
+    fireEvent.dragStart(alphaRow as HTMLElement, {
+      dataTransfer: createDataTransfer([], ['text/plain']),
+    });
+    fireEvent.dragOver(betaRow as HTMLElement, {
+      dataTransfer: createDataTransfer([], ['text/plain']),
+    });
+    fireEvent.drop(betaRow as HTMLElement, {
+      dataTransfer: createDataTransfer([], ['text/plain']),
+    });
+    fireEvent.dragEnd(alphaRow as HTMLElement, {
+      dataTransfer: createDataTransfer([], ['text/plain']),
+    });
+
+    await waitFor(() => {
+      expect(getRenderedFileNames()).toEqual(['beta.pdf', 'alpha.pdf']);
+    });
+
+    expect(getPageCountMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps arrow-button reordering working after drag support is added', async () => {
+    render(<MergeDialog open onClose={vi.fn()} />);
+
+    const dropZone = screen.getByLabelText('Drag and drop files here');
+    const alpha = createFile('alpha.pdf');
+    const beta = createFile('beta.pdf');
+
+    fireEvent.drop(dropZone, { dataTransfer: createDataTransfer([alpha, beta]) });
+    await screen.findByText('alpha.pdf');
+    await screen.findByText('beta.pdf');
+
+    fireEvent.click(screen.getAllByTitle('Move down')[0]);
+
+    await waitFor(() => {
+      expect(getRenderedFileNames()).toEqual(['beta.pdf', 'alpha.pdf']);
+    });
+  });
+});

--- a/src/renderer/components/editing/MergeDialog.tsx
+++ b/src/renderer/components/editing/MergeDialog.tsx
@@ -3,7 +3,7 @@
  * Dialog for merging multiple PDF files
  */
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dialog, Button, Spinner, useToast } from '../ui';
 import { pdfManipulationService } from '../../lib/pdf-manipulation.service';
@@ -16,22 +16,101 @@ interface MergeDialogProps {
 }
 
 interface FileItem {
+  id: string;
   file: File;
   name: string;
   pageCount?: number;
   pageRange?: string; // e.g., "1-5" or "all"
 }
 
+const FILE_DRAG_TYPE = 'Files';
+
+const createFileItemId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `merge_file_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+};
+
+const isPdfFile = (file: { name: string; type?: string }) => {
+  return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+};
+
+const reorderFiles = (items: FileItem[], draggedId: string, targetId: string) => {
+  const draggedIndex = items.findIndex((item) => item.id === draggedId);
+  const targetIndex = items.findIndex((item) => item.id === targetId);
+
+  if (draggedIndex === -1 || targetIndex === -1 || draggedIndex === targetIndex) {
+    return items;
+  }
+
+  const nextItems = [...items];
+  const [draggedItem] = nextItems.splice(draggedIndex, 1);
+  nextItems.splice(targetIndex, 0, draggedItem);
+  return nextItems;
+};
+
 export function MergeDialog({ open, onClose }: MergeDialogProps) {
   const [files, setFiles] = useState<FileItem[]>([]);
   const [includeCurrentPDF, setIncludeCurrentPDF] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isFileDragActive, setIsFileDragActive] = useState(false);
+  const [draggedFileId, setDraggedFileId] = useState<string | null>(null);
+  const [dragOverFileId, setDragOverFileId] = useState<string | null>(null);
+  const fileDragDepthRef = useRef(0);
 
   const { setModifiedPdf, setProcessing } = useEditingStore();
   const { document: currentDocument, fileName: currentFileName, totalPages: currentTotalPages } = usePDFStore();
   const toast = useToast();
   const { t } = useTranslation();
+
+  const resetDragState = () => {
+    setIsFileDragActive(false);
+    fileDragDepthRef.current = 0;
+    setDraggedFileId(null);
+    setDragOverFileId(null);
+  };
+
+  useEffect(() => {
+    if (!open) {
+      resetDragState();
+    }
+  }, [open]);
+
+  const createFileItems = async (incomingFiles: File[]) => {
+    const validFiles = incomingFiles.filter(isPdfFile);
+
+    if (validFiles.length === 0) {
+      setError(t('merge.invalidDrop'));
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const fileItems: FileItem[] = [];
+
+      for (const file of validFiles) {
+        const pageCount = await pdfManipulationService.getPageCount(file);
+        fileItems.push({
+          id: createFileItemId(),
+          file,
+          name: file.name,
+          pageCount,
+          pageRange: 'all',
+        });
+      }
+
+      setFiles((currentFiles) => [...currentFiles, ...fileItems]);
+      setError(null);
+    } catch (err: any) {
+      setError(err.message || 'Failed to load PDF files');
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   const handleSelectFiles = async () => {
     try {
@@ -39,24 +118,111 @@ export function MergeDialog({ open, onClose }: MergeDialogProps) {
 
       if (!selectedFiles || selectedFiles.length === 0) return;
 
-      setIsLoading(true);
-      const fileItems: FileItem[] = [];
-
-      for (const { name, data } of selectedFiles) {
+      const incomingFiles = selectedFiles.map(({ name, data }) => {
         const arrayBuffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
-        const file = new File([arrayBuffer], name, { type: 'application/pdf' });
-        const pageCount = await pdfManipulationService.getPageCount(file);
-        fileItems.push({ file, name, pageCount, pageRange: 'all' });
-      }
+        return new File([arrayBuffer], name, { type: 'application/pdf' });
+      });
 
-      // APPEND instead of REPLACE
-      setFiles([...files, ...fileItems]);
-      setError(null);
+      await createFileItems(incomingFiles);
     } catch (err: any) {
       setError(err.message || 'Failed to load PDF files');
-    } finally {
-      setIsLoading(false);
     }
+  };
+
+  const isExternalFileDrag = (e: React.DragEvent) => {
+    return Array.from(e.dataTransfer?.types ?? []).includes(FILE_DRAG_TYPE);
+  };
+
+  const handleFileDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!isExternalFileDrag(e)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    fileDragDepthRef.current += 1;
+    setIsFileDragActive(true);
+  };
+
+  const handleFileDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!isExternalFileDrag(e)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+
+    if (!isFileDragActive) {
+      setIsFileDragActive(true);
+    }
+  };
+
+  const handleFileDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!isExternalFileDrag(e)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    fileDragDepthRef.current = Math.max(fileDragDepthRef.current - 1, 0);
+
+    if (fileDragDepthRef.current === 0) {
+      setIsFileDragActive(false);
+    }
+  };
+
+  const handleFileDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+    if (!isExternalFileDrag(e)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    resetDragState();
+
+    const droppedFiles = Array.from(e.dataTransfer.files ?? []);
+    if (droppedFiles.length === 0) {
+      setError(t('merge.invalidDrop'));
+      return;
+    }
+
+    await createFileItems(droppedFiles);
+  };
+
+  const handleRowDragStart = (e: React.DragEvent<HTMLDivElement>, fileId: string) => {
+    e.stopPropagation();
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', fileId);
+
+    setDraggedFileId(fileId);
+    setDragOverFileId(fileId);
+  };
+
+  const handleRowDragOver = (e: React.DragEvent<HTMLDivElement>, fileId: string) => {
+    if (!draggedFileId) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'move';
+
+    if (dragOverFileId !== fileId) {
+      setDragOverFileId(fileId);
+    }
+  };
+
+  const handleRowDrop = (e: React.DragEvent<HTMLDivElement>, targetFileId: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!draggedFileId) {
+      resetDragState();
+      return;
+    }
+
+    setFiles((currentFiles) => reorderFiles(currentFiles, draggedFileId, targetFileId));
+    setDraggedFileId(null);
+    setDragOverFileId(null);
+  };
+
+  const handleRowDragEnd = () => {
+    setDraggedFileId(null);
+    setDragOverFileId(null);
   };
 
   const handleMerge = async () => {
@@ -85,8 +251,8 @@ export function MergeDialog({ open, onClose }: MergeDialogProps) {
       }
 
       // Add selected files
-      const pdfFiles = files.map(item => item.file);
-      const pageRanges = files.map(item => item.pageRange || 'all');
+      const pdfFiles = files.map((item) => item.file);
+      const pageRanges = files.map((item) => item.pageRange || 'all');
       finalFiles.push(...pdfFiles);
       finalRanges.push(...pageRanges);
 
@@ -104,6 +270,7 @@ export function MergeDialog({ open, onClose }: MergeDialogProps) {
 
         if (result.success) {
           toast.success('PDFs merged successfully!', `Saved to ${filePath.split(/[\\/]/).pop()}`);
+          resetDragState();
           onClose();
           setFiles([]);
         } else {
@@ -118,31 +285,49 @@ export function MergeDialog({ open, onClose }: MergeDialogProps) {
     }
   };
 
-  const handleRemoveFile = (index: number) => {
-    setFiles(files.filter((_, i) => i !== index));
+  const handleRemoveFile = (fileId: string) => {
+    setFiles((currentFiles) => currentFiles.filter((fileItem) => fileItem.id !== fileId));
   };
 
   const handleMoveUp = (index: number) => {
     if (index === 0) return;
-    const newFiles = [...files];
-    [newFiles[index - 1], newFiles[index]] = [newFiles[index], newFiles[index - 1]];
-    setFiles(newFiles);
+
+    setFiles((currentFiles) => {
+      const nextFiles = [...currentFiles];
+      [nextFiles[index - 1], nextFiles[index]] = [nextFiles[index], nextFiles[index - 1]];
+      return nextFiles;
+    });
   };
 
   const handleMoveDown = (index: number) => {
     if (index === files.length - 1) return;
-    const newFiles = [...files];
-    [newFiles[index], newFiles[index + 1]] = [newFiles[index + 1], newFiles[index]];
-    setFiles(newFiles);
+
+    setFiles((currentFiles) => {
+      const nextFiles = [...currentFiles];
+      [nextFiles[index], nextFiles[index + 1]] = [nextFiles[index + 1], nextFiles[index]];
+      return nextFiles;
+    });
   };
 
-  const handlePageRangeChange = (index: number, range: string) => {
-    const newFiles = [...files];
-    newFiles[index].pageRange = range;
-    setFiles(newFiles);
+  const handlePageRangeChange = (fileId: string, range: string) => {
+    setFiles((currentFiles) =>
+      currentFiles.map((fileItem) =>
+        fileItem.id === fileId
+          ? { ...fileItem, pageRange: range }
+          : fileItem
+      )
+    );
   };
 
   const totalPages = files.reduce((sum, file) => sum + (file.pageCount || 0), 0);
+
+  const fileDropZoneClasses = `
+    rounded-lg border-2 border-dashed transition-colors
+    ${isFileDragActive
+      ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20'
+      : 'border-gray-300 dark:border-gray-600'
+    }
+  `;
 
   return (
     <Dialog
@@ -159,11 +344,11 @@ export function MergeDialog({ open, onClose }: MergeDialogProps) {
             <Button variant="outline" onClick={handleSelectFiles} disabled={isLoading}>
               {isLoading ? <Spinner size="sm" /> : t('merge.addFiles')}
             </Button>
-            <Button 
-              onClick={handleMerge} 
+            <Button
+              onClick={handleMerge}
               disabled={((includeCurrentPDF && currentDocument ? 1 : 0) + files.length < 2) || isLoading}
             >
-              Merge {files.length > 0 && `(${totalPages + (includeCurrentPDF && currentDocument ? currentTotalPages : 0)} pages)`}
+              {t('merge.mergeButton')} {files.length > 0 && `(${totalPages + (includeCurrentPDF && currentDocument ? currentTotalPages : 0)} pages)`}
             </Button>
           </div>
         </div>
@@ -193,93 +378,125 @@ export function MergeDialog({ open, onClose }: MergeDialogProps) {
           </div>
         )}
 
-        {/* File list */}
-        {files.length === 0 ? (
-          <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 p-8 dark:border-gray-600">
-            <svg className="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">No files selected</p>
-            <Button variant="outline" onClick={handleSelectFiles} className="mt-4">
-              Select PDF Files
-            </Button>
-          </div>
-        ) : (
-          <div className="max-h-96 space-y-2 overflow-y-auto">
-            {files.map((fileItem, index) => (
-              <div
-                key={index}
-                className="flex items-center gap-3 rounded-md border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800"
-              >
-                {/* Order number */}
-                <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                  {index + 1}
-                </div>
-
-                {/* File info */}
-                <div className="flex-1 min-w-0">
-                  <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
-                    {fileItem.name}
-                  </p>
-                  {fileItem.pageCount && (
-                    <div className="flex items-center gap-2 mt-1">
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
-                        {fileItem.pageCount} pages
-                      </p>
-                      <span className="text-xs text-gray-400">•</span>
-                      <input
-                        type="text"
-                        value={fileItem.pageRange}
-                        onChange={(e) => handlePageRangeChange(index, e.target.value)}
-                        placeholder="all or 1-5,10-15"
-                        className="w-32 rounded border border-gray-300 px-2 py-0.5 text-xs dark:border-gray-600 dark:bg-gray-700"
-                      />
-                    </div>
-                  )}
-                </div>
-
-                {/* Actions */}
-                <div className="flex gap-1">
-                  <button
-                    onClick={() => handleMoveUp(index)}
-                    disabled={index === 0}
-                    className="rounded p-1 hover:bg-gray-100 disabled:opacity-30 dark:hover:bg-gray-700"
-                    title="Move up"
-                  >
-                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-                    </svg>
-                  </button>
-                  <button
-                    onClick={() => handleMoveDown(index)}
-                    disabled={index === files.length - 1}
-                    className="rounded p-1 hover:bg-gray-100 disabled:opacity-30 dark:hover:bg-gray-700"
-                    title="Move down"
-                  >
-                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                  </button>
-                  <button
-                    onClick={() => handleRemoveFile(index)}
-                    className="rounded p-1 text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
-                    title="Remove"
-                  >
-                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
-                </div>
+        <div
+          onDragEnter={handleFileDragEnter}
+          onDragOver={handleFileDragOver}
+          onDragLeave={handleFileDragLeave}
+          onDrop={handleFileDrop}
+          className={`space-y-3 ${fileDropZoneClasses} ${files.length === 0 ? 'p-8' : 'p-4'}`}
+          aria-label={t('merge.dragDrop')}
+        >
+          {files.length === 0 ? (
+            <div className="flex flex-col items-center justify-center text-center">
+              <svg className="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <p className="mt-2 text-sm font-medium text-gray-700 dark:text-gray-200">{t('merge.dragDrop')}</p>
+              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">{t('merge.dropHint')}</p>
+              <Button variant="outline" onClick={handleSelectFiles} className="mt-4" disabled={isLoading}>
+                {isLoading ? <Spinner size="sm" /> : 'Select PDF Files'}
+              </Button>
+            </div>
+          ) : (
+            <>
+              <div className="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-600 dark:bg-gray-900/40 dark:text-gray-300">
+                <span className="font-medium">{t('merge.dragDrop')}</span> {t('merge.dropHint')}
               </div>
-            ))}
-          </div>
-        )}
+
+              <div className="max-h-96 space-y-2 overflow-y-auto">
+                {files.map((fileItem, index) => (
+                  <div
+                    key={fileItem.id}
+                    draggable={!isLoading}
+                    onDragStart={(e) => handleRowDragStart(e, fileItem.id)}
+                    onDragOver={(e) => handleRowDragOver(e, fileItem.id)}
+                    onDrop={(e) => handleRowDrop(e, fileItem.id)}
+                    onDragEnd={handleRowDragEnd}
+                    className={`flex items-center gap-3 rounded-md border p-3 transition-colors ${
+                      draggedFileId === fileItem.id
+                        ? 'border-blue-500 bg-blue-50 opacity-60 dark:border-blue-400 dark:bg-blue-900/20'
+                        : dragOverFileId === fileItem.id && draggedFileId !== fileItem.id
+                          ? 'border-blue-400 bg-blue-50 dark:border-blue-300 dark:bg-blue-900/10'
+                          : 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800'
+                    } ${!isLoading ? 'cursor-move' : ''}`}
+                  >
+                    <div className="cursor-move text-gray-400" title={t('merge.reorderHint')}>
+                      <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+                      </svg>
+                    </div>
+
+                    {/* Order number */}
+                    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                      {index + 1}
+                    </div>
+
+                    {/* File info */}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                        {fileItem.name}
+                      </p>
+                      {fileItem.pageCount && (
+                        <div className="mt-1 flex items-center gap-2">
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            {fileItem.pageCount} pages
+                          </p>
+                          <span className="text-xs text-gray-400">•</span>
+                          <input
+                            type="text"
+                            value={fileItem.pageRange}
+                            onChange={(e) => handlePageRangeChange(fileItem.id, e.target.value)}
+                            placeholder="all or 1-5,10-15"
+                            className="w-32 rounded border border-gray-300 px-2 py-0.5 text-xs dark:border-gray-600 dark:bg-gray-700"
+                          />
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Actions */}
+                    <div className="flex gap-1">
+                      <button
+                        onClick={() => handleMoveUp(index)}
+                        disabled={index === 0}
+                        className="rounded p-1 hover:bg-gray-100 disabled:opacity-30 dark:hover:bg-gray-700"
+                        title="Move up"
+                      >
+                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={() => handleMoveDown(index)}
+                        disabled={index === files.length - 1}
+                        className="rounded p-1 hover:bg-gray-100 disabled:opacity-30 dark:hover:bg-gray-700"
+                        title="Move down"
+                      >
+                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={() => handleRemoveFile(fileItem.id)}
+                        className="rounded p-1 text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                        title="Remove"
+                      >
+                        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
 
         {/* Info */}
         {files.length > 0 && (
           <div className="rounded-md bg-blue-50 p-3 dark:bg-blue-900/20">
             <p className="text-sm text-blue-700 dark:text-blue-300">
-              {files.length} file{files.length > 1 ? 's' : ''} • {totalPages} total pages
+              {files.length} file{files.length > 1 ? 's' : ''} • {totalPages} total pages • {t('merge.reorderHint')}
             </p>
           </div>
         )}

--- a/src/renderer/components/editing/MergeDialog.tsx
+++ b/src/renderer/components/editing/MergeDialog.tsx
@@ -195,6 +195,7 @@ export function MergeDialog({ open, onClose }: MergeDialogProps) {
   };
 
   const handleRowDragOver = (e: React.DragEvent<HTMLDivElement>, fileId: string) => {
+    if (isExternalFileDrag(e)) return;
     if (!draggedFileId) return;
 
     e.preventDefault();
@@ -207,6 +208,8 @@ export function MergeDialog({ open, onClose }: MergeDialogProps) {
   };
 
   const handleRowDrop = (e: React.DragEvent<HTMLDivElement>, targetFileId: string) => {
+    if (isExternalFileDrag(e)) return;
+
     e.preventDefault();
     e.stopPropagation();
 

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -172,6 +172,9 @@
     "description": "Combine multiple PDF files into one",
     "addFiles": "Add Files",
     "dragDrop": "Drag and drop files here",
+    "dropHint": "or click Add Files to choose more PDFs",
+    "reorderHint": "Drag files to reorder merge order",
+    "invalidDrop": "Only PDF files can be added here",
     "mergeButton": "Merge PDFs",
     "success": "PDFs merged successfully"
   },

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -210,6 +210,9 @@
     "description": "Gabungkan beberapa file PDF menjadi satu",
     "addFiles": "Tambah File",
     "dragDrop": "Seret dan lepas file di sini",
+    "dropHint": "atau klik Tambah File untuk memilih PDF lain",
+    "reorderHint": "Seret file untuk mengubah urutan penggabungan",
+    "invalidDrop": "Hanya file PDF yang bisa ditambahkan di sini",
     "mergeButton": "Gabung PDF",
     "success": "PDF berhasil digabung"
   },

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,7 +4,7 @@
 
 - [x] Add drag-and-drop upload support to the merge dialog using the existing merge flow.
 - [x] Add drag-and-drop reordering for uploaded merge files with stable item ids.
-- [x] Update merge dialog copy in English and Indonesian for drop hints and invalid-drop feedback.
+- [x] Fix populated-state drop routing so dropping on an existing row still appends new PDF files.
 - [x] Add focused tests for file drop and reorder behavior in the merge dialog.
 - [x] Run targeted verification and fix any issues found.
 
@@ -12,7 +12,8 @@
 
 - Merge dialog now accepts dropped PDF files through the same append flow as the file picker, so upload behavior stays consistent.
 - Uploaded merge items now use stable ids and support drag-and-drop reordering without losing their page-range input state.
+- External PDF drops over an existing row now fall through to the parent drop zone instead of being consumed by row reorder handlers.
 - Added English and Indonesian copy for drop hints, reorder hints, and invalid file-drop feedback.
-- Added focused component tests covering PDF drop, invalid drop, drag reorder, and existing arrow-button reorder.
+- Added focused component tests covering empty-state PDF drop, populated-state row drop append, invalid drop, drag reorder, and existing arrow-button reorder.
 - Verification: `npx vitest run src/renderer/components/editing/MergeDialog.test.tsx` passed.
 - Verification note: `npm run type-check` still fails because of pre-existing repo-wide TypeScript issues outside this feature, but filtering the output showed no remaining `MergeDialog` errors from these changes.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,169 +1,18 @@
-# 🖨️ Print Feature - Final Implementation
+# Merge PDF Drag-and-Drop
 
-## 🎯 User Request
+## Todo
 
-User ingin print feature yang **langsung muncul print dialog** tanpa harus Ctrl+P lagi di browser.
+- [x] Add drag-and-drop upload support to the merge dialog using the existing merge flow.
+- [x] Add drag-and-drop reordering for uploaded merge files with stable item ids.
+- [x] Update merge dialog copy in English and Indonesian for drop hints and invalid-drop feedback.
+- [x] Add focused tests for file drop and reorder behavior in the merge dialog.
+- [x] Run targeted verification and fix any issues found.
 
-## 🔄 Approaches yang Dicoba
+## Review
 
-### ❌ Approach #1: HTML Wrapper + Auto-Print JavaScript
-- Generate HTML dengan `<iframe>` yang load PDF
-- Trigger `window.print()` via JavaScript
-- **Result**: Browser blocking `window.print()` dari local file (security policy)
-
-### ❌ Approach #2: Electron Native Print
-- Gunakan `BrowserWindow.webContents.print()`
-- Load PDF sebagai base64 data URL
-- Auto-trigger print dialog
-- **Result**: Print dialog muncul, TAPI **"This app doesn't support print preview"** ❌
-- User tidak bisa lihat preview sebelum print
-
-### ✅ Approach #3: Browser dengan Preview (FINAL)
-- Kembali ke approach yang reliable
-- Open PDF di Microsoft Edge / system default viewer
-- User bisa **lihat preview** sebelum print
-- User manual Ctrl+P untuk print
-- **Result**: WORKING dengan full preview! ✅
-
----
-
-## ✅ Final Implementation
-
-### **Files Changed:**
-
-1. **[src/main/main.ts](src/main/main.ts#L180-L254)**
-   - Open PDF di system browser (Microsoft Edge on Windows)
-   - Save PDF ke temp file
-   - Use `shell.exec()` untuk open Edge dengan PDF path
-   - Cross-platform support (Windows/macOS/Linux)
-
-2. **[src/renderer/i18n/locales/en.json](src/renderer/i18n/locales/en.json#L421-L428)**
-   - "Opening PDF for printing..."
-   - "PDF opened in browser"
-   - "You can now preview and print the document using Ctrl+P"
-
-3. **[src/renderer/i18n/locales/id.json](src/renderer/i18n/locales/id.json#L421-L428)**
-   - "Membuka PDF untuk dicetak..."
-   - "PDF dibuka di browser"
-   - "Anda sekarang dapat melihat preview dan mencetak dokumen menggunakan Ctrl+P"
-
-4. **[src/main/services/auto-updater.service.ts](src/main/services/auto-updater.service.ts#L34-L53)**
-   - Fixed: Moved autoUpdater config ke `initialize()` method
-   - Now only initializes after app is ready
-   - Manual update check tetap working ✅
-
----
-
-## 🎯 User Flow
-
-```
-User klik Print (Ctrl+P)
-    ↓
-Toast: "Opening PDF for printing..."
-    ↓
-[2 seconds delay]
-    ↓
-Microsoft Edge terbuka dengan PDF
-    ↓
-✅ USER BISA LIHAT PREVIEW!
-    ↓
-Toast: "PDF opened in browser - You can now preview and print using Ctrl+P"
-    ↓
-User tekan Ctrl+P di browser
-    ↓
-Print dialog muncul WITH PREVIEW ✅
-    ↓
-User configure settings & print
-    ↓
-Done!
-```
-
----
-
-## ✨ Benefits
-
-1. ✅ **Full Preview** - User bisa lihat PDF sebelum print
-2. ✅ **Familiar Interface** - User pakai viewer yang sudah biasa (Edge/Chrome/Adobe)
-3. ✅ **All Print Options** - Semua settings tersedia (orientation, pages, margins, dll)
-4. ✅ **Reliable** - No browser security policy blocking
-5. ✅ **Cross-platform** - Works di Windows, macOS, Linux
-6. ✅ **No Loop Issue** - Explicit Edge path prevents opening PDF Kit again
-7. ✅ **Multi-language** - Toast messages dalam EN/ID
-
----
-
-## 📊 Trade-offs
-
-### ✅ Pros:
-- User dapat **full preview** sebelum print
-- Menggunakan **PDF viewer yang sudah familiar**
-- **Semua print options** tersedia
-- **Sangat reliable** - no edge cases
-
-### ⚠️ Cons:
-- User harus **manual Ctrl+P** di browser (1 extra step)
-- Browser window terbuka (tapi ini expected behavior)
-
----
-
-## 🧪 Testing Instructions
-
-1. **Run aplikasi:**
-   ```bash
-   npm run dev
-   # atau
-   npm run build && npm run package
-   ```
-
-2. **Test Print:**
-   - Buka PDF file
-   - Klik Print button atau tekan Ctrl+P
-   - Verify: Microsoft Edge terbuka dengan PDF
-   - Verify: PDF preview visible ✅
-   - Tekan Ctrl+P di Edge
-   - Verify: Print dialog muncul dengan preview ✅
-   - Configure settings & print
-
-3. **Test Scenarios:**
-   - ✅ PDF kecil (<1MB)
-   - ✅ PDF besar (>10MB)
-   - ✅ Multiple prints
-   - ✅ Cancel print
-   - ✅ Different printers
-   - ✅ Bahasa Indonesia
-   - ✅ Bahasa English
-
----
-
-## 📝 About Auto-Updater
-
-**User Question:** "tp klo user update manual dengan click check updates g ada masalahkan?"
-
-**Answer:** ✅ **TIDAK ADA MASALAH!**
-
-Auto-updater error hanya terjadi di **dev mode startup**. Ketika user klik "Check for Updates":
-- ✅ App sudah fully initialized
-- ✅ IPC handler will work normally
-- ✅ Auto-updater dipanggil setelah app ready
-- ✅ Update check akan berhasil
-
----
-
-## 🎉 Conclusion
-
-**Final approach adalah yang paling simple dan reliable:**
-- Open PDF di browser → User lihat preview → User Ctrl+P → Print
-
-Ini adalah **standard behavior** yang user sudah familiar. Better UX dengan preview daripada auto-print tanpa preview.
-
----
-
-**Status:** ✅ **IMPLEMENTED & WORKING**
-**Date:** January 3, 2026
-**Build Status:** ✅ SUCCESS
-**Ready for:** Production use
-
----
-
-**Implementation by:** Claude Code 🤖
-**Total Time:** ~2 hours (including 3 different approaches)
+- Merge dialog now accepts dropped PDF files through the same append flow as the file picker, so upload behavior stays consistent.
+- Uploaded merge items now use stable ids and support drag-and-drop reordering without losing their page-range input state.
+- Added English and Indonesian copy for drop hints, reorder hints, and invalid file-drop feedback.
+- Added focused component tests covering PDF drop, invalid drop, drag reorder, and existing arrow-button reorder.
+- Verification: `npx vitest run src/renderer/components/editing/MergeDialog.test.tsx` passed.
+- Verification note: `npm run type-check` still fails because of pre-existing repo-wide TypeScript issues outside this feature, but filtering the output showed no remaining `MergeDialog` errors from these changes.


### PR DESCRIPTION
# Pull Request

## Description

Fix merge dialog drag-and-drop behavior so users can add more PDF files even when the merge list already contains files. External file drops on top of existing rows now append correctly instead of being intercepted by row-reorder drag handlers.

Fixes #\<issue number>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Fixed merge dialog drag event routing so external PDF drops over existing file rows bubble to the parent add-files drop zone
- Kept internal drag-and-drop reordering behavior intact for already-added merge rows
- Added regression coverage for dropping a new PDF onto an existing row, alongside existing merge dialog drag/drop tests
- Updated dev Electron startup flow to build the main process before launch so `npm run dev` starts correctly from a clean clone

## Screenshots (if applicable)

<img width="936" height="777" alt="{536C5FC7-6049-4B46-AF31-775EA350694A}" src="https://github.com/user-attachments/assets/35658fb0-6cfe-4a1d-bd30-aaf060a62b65" />

https://github.com/user-attachments/assets/6902331c-3937-4a16-bead-2ced14c09c2e



## Testing

- [ ] Tests pass locally (`npm run test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Lint passes (`npm run lint`)

Notes:
- Verified focused test: `npx vitest run src/renderer/components/editing/MergeDialog.test.tsx`
- Verified `npm run dev` starts successfully after the Electron startup fix, then was stopped
- I did not run full `npm run test`, `npm run build`, or `npm run lint` end-to-end here